### PR TITLE
ci: fix typo in build-pages.yml workflow

### DIFF
--- a/.github/workflows/build-pages.yml
+++ b/.github/workflows/build-pages.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: cache
-          key: ${[ runner.os }}-apt-ftparchive
+          key: ${{ runner.os }}-apt-ftparchive
 
       - name: 🏗 Prepare folders
         run: |


### PR DESCRIPTION
This PR fixes only a typo in the build-pages workflow. In this workflow is a `[` instead of a `{` in the key attribute for the actions/cache step.