### PR TITLE
Replace `sudo echo` in apt sources code sample with `sudo tee`

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -17,7 +17,7 @@
 
     <code>
         curl -s --compressed "https://apt.octoprint.org/octoprint.gpg.key" | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/octoprint.gpg > /dev/null<br>
-        sudo echo "deb https://apt.octoprint.org/debian $(lsb_release -cs) rpi" > /etc/apt/sources.list.d/octoprint.list<br>
+        echo "deb https://apt.octoprint.org/debian $(lsb_release -cs) rpi" | sudo tee /etc/apt/sources.list.d/octoprint.list<br>
         sudo apt update<br>
     </code>
 


### PR DESCRIPTION
`sudo echo` doesn't make the file write operation privileged, but this works with passing the input to privileged `tee`.